### PR TITLE
get rid of openlattice:api dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,6 @@ dependencies {
     compile "org.apache.olingo:odata-commons-core:${odata_version}"
 
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-smile:${jackson_version}"
-    compile "com.openlattice:api:${api_version}"
 
     testCompile "junit:junit:${junit_version}"
 

--- a/src/main/java/com/openlattice/chronicle/ChronicleStudyApi.java
+++ b/src/main/java/com/openlattice/chronicle/ChronicleStudyApi.java
@@ -1,12 +1,8 @@
 package com.openlattice.chronicle;
 
 import com.google.common.base.Optional;
-import com.openlattice.chronicle.data.ChronicleAppsUsageDetails;
-import com.openlattice.chronicle.data.ChronicleQuestionnaire;
-import com.openlattice.chronicle.data.FileType;
-import com.openlattice.chronicle.data.ParticipationStatus;
+import com.openlattice.chronicle.data.*;
 import com.openlattice.chronicle.sources.Datasource;
-import com.openlattice.data.DeleteType;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
 import retrofit2.http.*;
 

--- a/src/main/java/com/openlattice/chronicle/data/DeleteType.java
+++ b/src/main/java/com/openlattice/chronicle/data/DeleteType.java
@@ -1,0 +1,9 @@
+package com.openlattice.chronicle.data;
+
+/**
+ * @author alfoncenzioka &lt;alfonce@openlattice.com&gt;
+ */
+public enum DeleteType {
+    Soft,
+    Hard
+}


### PR DESCRIPTION
PR:
openlattice:api dependency results in multiple duplicate class dependency conflicts in the android project. For example:
```
Duplicate class javax.xml.bind.util.Messages found in modules jakarta.xml.bind-api-2.3.2.jar (jakarta.xml.bind:jakarta.xml.bind-api:2.3.2) and jaxb-api-2.2.jar (javax.xml.bind:jaxb-api:2.2)

```

Excluding either `group: jakarta.xml.bind, module: jakarta.xml.bind-api` or `group: javax.xml.bind, module: jaxb-api` results in a  `IllegalArgumentException` and the project fails to compile. 

It seems that the closest to ideal fix would be to get rid of the openlattice-api  by copying the `DeleteType` enum in the chronicle api project.
