### PR TITLE
get all questionnaires associated with a study

### DIFF
--- a/src/main/java/com/openlattice/chronicle/ChronicleStudyApi.java
+++ b/src/main/java/com/openlattice/chronicle/ChronicleStudyApi.java
@@ -240,15 +240,14 @@ public interface ChronicleStudyApi {
     );
 
     /**
-     * Get active questionnaires for a given study
-     * Active questionnaires have ol.active property set to true
+     * Get all questionnaires for a given study
      *
      * @param studyId - studyId
      * @return a mapping entityKeyId to entity details(name, description, cron etc)
-     * or an empty Map if no active notifications are found.
+     * or an empty Map if no questionnaires are found.
      */
-    @GET( BASE + STUDY_ID_PATH + QUESTIONNAIRES + ACTIVE )
-    Map<UUID, Map<FullQualifiedName, Set<Object>>> getActiveQuestionnaires(
+    @GET( BASE + STUDY_ID_PATH + QUESTIONNAIRES )
+    Map<UUID, Map<FullQualifiedName, Set<Object>>> getStudyQuestionnaires(
             @Path( STUDY_ID ) UUID studyId
     );
 }


### PR DESCRIPTION
PR: 
In the android app, we need to be able to cancel notifications for questionnaires that are no longer considered active. To achieve this, we can either save information about questionnaires on the device or get all questionnaires associated with a study and decide whether to cancel / schedule notification based on the `ol.active` property. 

The second option is preferable because it voids the need to save questionnaire metadata on the device. 
