### PR TITLE
fix json annotation

### DIFF
--- a/src/main/java/com/openlattice/chronicle/ChronicleFields.java
+++ b/src/main/java/com/openlattice/chronicle/ChronicleFields.java
@@ -13,6 +13,7 @@ public final class ChronicleFields {
     public static final String OS_VERSION      = "osVersion";
     public static final String SDK_VERSION     = "sdkVersion";
     public static final String ADDITIONAL_INFO = "additionalInfo";
+    public static final String TYPE            = "type";
 
     private ChronicleFields() {
     }

--- a/src/main/java/com/openlattice/chronicle/sources/AndroidDevice.java
+++ b/src/main/java/com/openlattice/chronicle/sources/AndroidDevice.java
@@ -1,39 +1,33 @@
 package com.openlattice.chronicle.sources;
 
-import static com.openlattice.chronicle.ChronicleFields.ADDITIONAL_INFO;
-import static com.openlattice.chronicle.ChronicleFields.BRAND;
-import static com.openlattice.chronicle.ChronicleFields.CODENAME;
-import static com.openlattice.chronicle.ChronicleFields.DEVICE;
-import static com.openlattice.chronicle.ChronicleFields.DEVICE_ID;
-import static com.openlattice.chronicle.ChronicleFields.MODEL;
-import static com.openlattice.chronicle.ChronicleFields.OS_VERSION;
-import static com.openlattice.chronicle.ChronicleFields.PRODUCT;
-import static com.openlattice.chronicle.ChronicleFields.SDK_VERSION;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Optional;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import static com.openlattice.chronicle.ChronicleFields.*;
 
 /**
  * Represents the information we collect about each device.
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
-@JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include= JsonTypeInfo.As.PROPERTY, property="@class")
 public class AndroidDevice implements Datasource {
     private final String              device;
     private final String              model;
     private final String              codename;
     private final String              brand;
-    private final String osVersion;
+    private final String              osVersion;
     private final String              sdkVersion;
     private final String              product;
     private final String              deviceId;
     private final Map<String, Object> additionalInfo;
+
+    @JsonProperty
+    private String className = this.getClass().getSimpleName();
 
     @JsonCreator
     public AndroidDevice(
@@ -50,7 +44,7 @@ public class AndroidDevice implements Datasource {
         this.model = model;
         this.codename = codename;
         this.brand = brand;
-        this.osVersion=osVersion;
+        this.osVersion = osVersion;
         this.sdkVersion = sdkVersion;
         this.product = product;
         this.deviceId = deviceId;

--- a/src/main/java/com/openlattice/chronicle/sources/Datasource.java
+++ b/src/main/java/com/openlattice/chronicle/sources/Datasource.java
@@ -1,11 +1,16 @@
 package com.openlattice.chronicle.sources;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
-@JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include= JsonTypeInfo.As.PROPERTY, property="@class")
+@JsonTypeInfo( use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "className" )
+@JsonSubTypes( {
+        @JsonSubTypes.Type( value = AndroidDevice.class, name = "AndroidDevice" )
+} )
 public interface Datasource {
-
 }
+


### PR DESCRIPTION
We were getting this which leads to failed enrollments.
```
2020-06-24T00:03:23,362 ERROR [qtp1678770626-115] com.openlattice.chronicle.util.ChronicleServerExceptionHandler -
org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Missing type id when trying to resolve subtype of [simple type, class com.openlattice.chronicle.sources.Datasource]: missin
g type id property '@class'; nested exception is com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Missing type id when trying to resolve subtype of [simple type, class com.openlattice.chronicle.sourc
es.Datasource]: missing type id property '@class'
 at [Source: (PushbackInputStream); line: 1, column: 188]
        at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:245) ~[spring-web-5.1.5.RELEASE.jar:5.1.5.RELEASE]
        at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.read(AbstractJackson2HttpMessageConverter.java:227) ~[spring-web-5.1.5.RELEASE.jar:5.1.5.RELEASE]
        at org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConverterMethodArgumentResolver.readWithMessageConverters(AbstractMessageConverterMethodArgumentResolver.java:204) ~[spring-webmv
c-5.1.5.RELEASE.jar:5.1.5.RELEASE]
        at org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.readWithMessageConverters(RequestResponseBodyMethodProcessor.java:157) ~[spring-webmvc-5.1.5.RELEASE.jar:5.1.
5:04
Caused by: com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Missing type id when trying to resolve subtype of [simple type, class com.openlattice.chronicle.sources.Datasource]: missing type id proper
ty '@class'
 at [Source: (PushbackInputStream); line: 1, column: 188]
        at com.fasterxml.jackson.databind.exc.InvalidTypeIdException.from(InvalidTypeIdException.java:43) ~[jackson-databind-2.10.1.jar:2.10.1]
        at com.fasterxml.jackson.databind.DeserializationContext.missingTypeIdException(DeserializationContext.java:1768) ~[jackson-databind-2.10.1.jar:2.10.1]
```

Apparently, jackson doesn't work well with Optional variables in (de)serialization.  No idea why this only came up now, maybe some dependency update.  Tested in rehearsal:
https://github.com/openlattice/rehearsal/pull/70

based on this: https://stackoverflow.com/questions/49071166/jackson-java-util-optional-serialization-does-not-include-type-id

